### PR TITLE
Add documenation to findEach

### DIFF
--- a/docs/query/findEach.html
+++ b/docs/query/findEach.html
@@ -5,7 +5,45 @@
   <#assign findEach= "true">
 </head>
 <body>
-<h2>findEach</h2>
+<h2>findEach (process large queries, one bean at a time)</h2>
 
+<p>
+This method is appropriate to process very large query results as the
+beans are consumed one at a time and do not need to be held in memory
+  (unlike <a href="/findList">findList</a> <a href='findSet'>findSet</a> etc)
+</p>
+<p>
+  Note that <code>findEach</code> (and <a href="/findEachWhile">findEachWhile</a> and <a href="/findIterate">findIterate</a>) uses a "per graph"
+persistence context scope and adjusts jdbc fetch buffer size for large
+queries. As such it is better to use findList for small queries.
+</p>
+<p>
+Note that internally Ebean can inform the JDBC driver that it is expecting larger
+resultSet and specifically for <code>MySQL</code> this hint is required to stop it's JDBC driver
+from buffering the entire resultSet. As such, for smaller resultSets <a href="/findList">findList()</a> is
+generally preferable.
+</p>
+<p>
+  Compared with <a href="/findEachWhile">findEachWhile</a> this will always process all the beans where as
+  <a href="/findEachWhile">findEachWhile</a> provides a way to stop processing the query result early before
+all the beans have been read.
+</p>
+<p>
+  This method is functionally equivalent to <a href="/findIterate">findIterate()</a> but instead of using an
+  iterator uses the <code>Consumer<T></code> interface which is better suited to use with Java8 closures.
+</p>
+
+
+ ```java
+  ebeanServer.find(Customer.class)
+     .where().eq("status", Status.NEW)
+     .order().asc("id")
+     .findEach((Customer customer) -> {
+
+       // do something with customer
+       System.out.println("-- visit " + customer);
+     });
+ ```
+  
 </body>
 </html>


### PR DESCRIPTION
Copied the documentation from the `Javadoc` to the `findEac.h` page, added the links to the corresponding methods and made the code highlighted