### PR TITLE
Update link to QueryIterator

### DIFF
--- a/docs/query/findIterate.html
+++ b/docs/query/findIterate.html
@@ -16,7 +16,7 @@ Execute the query iterating over the results. This is good for processing large 
  queries. As such it is better to use <a href='findList'>findList</a> for small queries.
  </p>
  <p>
- Remember that with <a href='http://ebean-orm.github.io/apidoc/11/io/ebean/QueryIterator.html'>QueryIterator</a> you must call <code>close()</code>
+ Remember that with <a href='http://ebean-orm.github.io/apidoc/current/io/ebean/QueryIterator.html'>QueryIterator</a> you must call <code>close()</code>
  when you have finished iterating the results (typically in a finally block).
  </p>
  <p>


### PR DESCRIPTION
Update the link to the Javadocs to reference the latest Javadoc API (under `/api/current`)