### PR TITLE
Fix broken GitHub links on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,12 @@
       <p>&nbsp;</p>
       <!--<a class="btn btn-w" href="/docs/getting-started"><i class="fas fa-angle-right"></i>  Get Started</a>-->
       <!--<a class="btn btn-w" href="/docs/"> Documentation</a>-->
-      <!--<a class="btn btn-w" href="https://githib.com/ebean-orm"><i class="fab fa-github"></i> Github</a>-->
+      <!--<a class="btn btn-w" href="https://github.com/ebean-orm"><i class="fab fa-github"></i> Github</a>-->
 
       <h4><a class="bright-link" href="/docs/getting-started"><i class="fas fa-angle-right"></i> Getting started</a>
       </h4>
       <h4><a href="/docs"><i class="fas fa-angle-right"></i> Documentation</a></h4>
-      <h4><a href="https://githib.com/ebean-orm"><i class="fas fa-angle-right"></i> Github</a></h4>
+      <h4><a href="https://github.com/ebean-orm"><i class="fas fa-angle-right"></i> Github</a></h4>
     </div>
 
   </div>


### PR DESCRIPTION
Hi,
This is a minor typo fix.
I've visited the [home page](https://ebean.io/) of the project and noticed that the GitHub link seems to be broken -- it leads to a non-existing domain.
Thanks!