### PR TITLE
Fix wrong URL for query/findIterate link

### DIFF
--- a/docs/query/index.html
+++ b/docs/query/index.html
@@ -69,7 +69,7 @@
       <h4><a href="/docs/query/findList">findList</a></h4>
       <h4><a href="/docs/query/findMap">findMap</a></h4>
       <h4><a href="/docs/query/findEach">findEach</a> ( large query )</h4>
-      <h4><a href="/docs/query/findEach">findIterate</a> ( large query )</h4>
+      <h4><a href="/docs/query/findIterate">findIterate</a> ( large query )</h4>
       <h4><a href="/docs/query/findNative">findNative</a> ( sql )</h4>
     </div>
 


### PR DESCRIPTION
`findIterate` link at the query documentation pointed incorrectly to `findEach` page. Resolves #34