### PR TITLE
remove byte order mark from history videolink

### DIFF
--- a/_vids/history_1.ftl
+++ b/_vids/history_1.ftl
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-4">
-    <@video_item "WxBDGQJelb0﻿" "Introduction" "Walk through the @History / SQL2011 support with Oracle and Postgres"/>
+    <@video_item "WxBDGQJelb0" "Introduction" "Walk through the @History / SQL2011 support with Oracle and Postgres"/>
   </div>
   <div class="col-md-4">
   <@video_item "YOuElXoidxk" "Comparison to Hibernate Envers" "Comparison with the approach taken by Hibernate Envers"/>

--- a/docs/features/history.html
+++ b/docs/features/history.html
@@ -11,7 +11,7 @@
   <h2 id="videos">Videos</h2>
   <div class="row">
     <div class="col-md-6">
-    <@video_item "WxBDGQJelb0﻿" "Introduction" "Walk through the @History / SQL2011 support with Oracle and Postgres"/>
+    <@video_item "WxBDGQJelb0" "Introduction" "Walk through the @History / SQL2011 support with Oracle and Postgres"/>
     </div>
 
     <div class="col-md-6">


### PR DESCRIPTION
videolink was generated as "https://youtu.be/WxBDGQJelb0%EF%BB%BF" because of the stray bom