### PR TITLE
Fixes on the Persist page

### DIFF
--- a/docs/persist/index.html
+++ b/docs/persist/index.html
@@ -158,8 +158,8 @@ Integer returnValue = (Integer) cs.getObject(2);
 
 <h2 id="rawjdbc">Raw JDBC</h2>
 
-<p>You can't always predict when your application requirements can't be meet with the
-features in Ebean. It is nice you now you can easily use raw JDBC if and when you need
+<p>You can't always predict when your application requirements can't be met with the
+features in Ebean. It is nice to know you can easily use raw JDBC if and when you need
 to.</p>
 <p>The java.sql.Connection object can be returned from a transaction, and with that you can
 perform any raw JDBC calls you like.</p>

--- a/docs/persist/index.html
+++ b/docs/persist/index.html
@@ -184,7 +184,7 @@ manage its "L2" cache as well as maintain Lucene text indexes.</p>
 
 <h2 id="batch_processing">JDBC Batch</h2>
 <p>
-  Ebean provides support for JDBC batch processing.  Batch processing groups related SQL statements into a batch and submits them with one call to the database.
+  Ebean provides support for JDBC batch processing. Batch processing groups related SQL statements into a batch and submits them with one call to the database.
 </p>
 <p>
   Batch settings can be configured through application.properties or through DatabaseConfig, and can be overridden per transaction.

--- a/docs/persist/index.html
+++ b/docs/persist/index.html
@@ -178,9 +178,6 @@ try (Transaction transaction = DB.beginTransaction()) {
 }
 ```
 
-<p>The <b>transaction.addModification()</b> in the code above informs Ebean that your jdbc code
-updated the shipping_details table. Ebean uses this information to automatically
-manage its "L2" cache as well as maintain Lucene text indexes.</p>
 
 <h2 id="batch_processing">JDBC Batch</h2>
 <p>


### PR DESCRIPTION
Some changes on the persist page with typos and some sentence that did not make sense.
Removed reference to part of the code sample that is no longer there.

Affected part of the website: https://ebean.io/docs/persist/