### PR TITLE
Changing Yugabyte with YugabyteDB in documentation

### DIFF
--- a/_nav/database-platforms.ftl
+++ b/_nav/database-platforms.ftl
@@ -10,7 +10,7 @@
   <@smallnav activeCheck="${n2_sqlite!''}" url="/docs/database/sqlite" title="Sqlite"/>
   <@smallnav activeCheck="${n2_clickhouse!''}" url="/docs/database/clickhouse" title="ClickHouse"/>
   <@smallnav activeCheck="${n2_cockroach!''}" url="/docs/database/cockroach" title="Cockroach"/>
-  <@smallnav activeCheck="${n2_yugabyte!''}" url="/docs/database/yugabyte" title="Yugabyte"/>
+  <@smallnav activeCheck="${n2_yugabyte!''}" url="/docs/database/yugabyte" title="YugabyteDB"/>
   <@smallnav activeCheck="${n2_nuodb!''}" url="/docs/database/nuodb" title="NuoDB"/>
   <@smallnav activeCheck="${n2_elasticsearch!''}" url="/docs/database/elasticsearch" title="ElasticSearch"/>
   <@smallnav activeCheck="${n2_redis!''}" url="/docs/database/redis" title="Redis"/>

--- a/docs/database/cockroach/index.html
+++ b/docs/database/cockroach/index.html
@@ -63,7 +63,7 @@ public class Main {
 }
 </pre>
 
-<@next_edit "Yugabyte" "/docs/database/yugabyte" "/docs/database/cockroach/index.html"/>
+<@next_edit "YugabyteDB" "/docs/database/yugabyte" "/docs/database/cockroach/index.html"/>
 
 </body>
 </html>

--- a/docs/database/index.html
+++ b/docs/database/index.html
@@ -22,7 +22,7 @@
     <h4><a href="/docs/database/oracle">Oracle</a></h4>
     <h4><a href="/docs/database/db2">DB2</a></h4>
     <h4><a href="/docs/database/hana">SAP Hana</a></h4>
-    <h4><a href="/docs/database/yugabyte">Yugabyte</a></h4>
+    <h4><a href="/docs/database/yugabyte">YugabyteDB</a></h4>
   </div>
   <div>
     <h4><a href="/docs/database/sqlite">SQLite</a></h4>

--- a/docs/database/yugabyte/index.html
+++ b/docs/database/yugabyte/index.html
@@ -1,19 +1,19 @@
 <html>
 <head>
-  <title>Yugabyte | Ebean ORM</title>
+  <title>YugabyteDB | Ebean ORM</title>
   <meta name="layout" content="_layout2/base-docs.html"/>
   <meta name="bread1" content="Database platforms" href="/docs/database"/>
-  <meta name="bread2" content="Yugabyte" href="/docs/database/yugabyte"/>
+  <meta name="bread2" content="YugabyteDB" href="/docs/database/yugabyte"/>
   <#assign n0_docs="active">
   <#assign n1_platforms="active">
   <#assign n2_yugabyte="active">
 </head>
 <body>
-<h2>Yugabyte</h2>
+<h2>YugabyteDB</h2>
 
 <h3>Testing</h3>
 <p>
-  To test against Yugabyte docker test container set the <em>platform</em> to <code>yugabyte</code> in
+  To test against YugabyteDB docker test container set the <em>platform</em> to <code>yugabyte</code> in
   <code>src/test/resources/application-test.yaml</code>
 </p>
 <p>
@@ -31,13 +31,13 @@ ebean:
 <h2 id="ebean-yugabyte">ebean-yugabyte dependency</h2>
 <p>
   We can use the <code>io.ebean:ebean-yugabyte</code> dependency rather than <code>io.ebean:ebean</code> if we want to only
-  bring in the Yugabyte specific platform code. Depending on <code>io.ebean:ebean</code> will bring in all platforms.
+  bring in the YugabyteDB specific platform code. Depending on <code>io.ebean:ebean</code> will bring in all platforms.
 </p>
 
 
 <h2 id="starting">Docker container</h2>
 <p>
-  We can programmatically start a docker container version of Yugabyte.
+  We can programmatically start a docker container version of YugabyteDB.
 </p>
 <p>
   The below uses <code>ebean-test-docker</code> dependency which already comes with <code>ebean-test</code>.

--- a/docs/features/encryption.html
+++ b/docs/features/encryption.html
@@ -83,7 +83,7 @@ public interface Encryptor {
   The default DB encryption decryption functions used for each platform are:
 </p>
 <ul>
-  <li><b>Postgres, Yugabyte</b> - pgp_sym_decrypt(), pgp_sym_encrypt()</li>
+  <li><b>Postgres, YugabyteDB</b> - pgp_sym_decrypt(), pgp_sym_encrypt()</li>
   <li><b>MySql, MariaDB</b> - aes_encrypt(), aes_decrypt()</li>
   <li><b>SQL Server</b> - DecryptByPassPhrase(), EncryptByPassPhrase()</li>
   <li><b>Oracle</b> - requires dbms_crypto and uses custom functions for encryption and decryption</li>
@@ -183,7 +183,7 @@ public interface EncryptKeyManager {
     Properties using Java client encryption should only use <b>EQ</b> (equal to) operator in WHERE clauses
   </li>
   <li>
-    DB Encryption support built in for H2, Postgres, Yugabyte, MySql, MariaDB, Sql Server and Oracle.
+    DB Encryption support built in for H2, Postgres, YugabyteDB, MySql, MariaDB, Sql Server and Oracle.
   </li>
   <li>
     We can not use Encryption with positioned (1,2,3...) parameters. We must

--- a/docs/testing/index.html
+++ b/docs/testing/index.html
@@ -163,7 +163,7 @@ ebean:
   , <a href="/docs/database/postgres">postgres</a>
   , <a href="/docs/database/sqlite">sqlite</a>
   , <a href="/docs/database/sqlserver">sqlserver</a>
-  , <a href="/docs/database/yugabyte">yugabyte</a>
+  , <a href="/docs/database/yugabyte">yugabytedb</a>
 </p>
 
 <h2 id="ddlmode">DDL Mode</h2>
@@ -207,7 +207,7 @@ ebean:
 <h2 id="docker">Docker test containers</h2>
 <p>
   Ebean provides docker test containers for Postgres, MariaDB, MySql, SqlServer, Oracle, Hana, DB2, Clickhouse,
-  CockroachDB, Yugabyte, Redis, ElasticSearch plus DynamoDB and Localstack.
+  CockroachDB, YugabyteDB, Redis, ElasticSearch plus DynamoDB and Localstack.
 </p>
 <p>
   <em>ebean-test</em> automatically manages the docker containers and sets them up ready for

--- a/search.json
+++ b/search.json
@@ -1272,7 +1272,7 @@
   "url":"/docs/database/sqlite#ebean-sqlite"
 }
 ,{
-  "title":"Yugabyte",
+  "title":"YugabyteDB",
   "caption":"",
   "category":"Database platforms",
   "priority":"3",
@@ -1280,7 +1280,7 @@
   "url":"/docs/database/yugabyte"
 }
 ,{
-  "title":"Yugabyte - Docker container",
+  "title":"YugabyteDB - Docker container",
   "caption":"",
   "category":"Database platforms",
   "priority":"3",
@@ -1288,7 +1288,7 @@
   "url":"/docs/database/yugabyte#starting"
 }
 ,{
-  "title":"Yugabyte - ebean-yugabyte dependency",
+  "title":"YugabyteDB - ebean-yugabyte dependency",
   "caption":"",
   "category":"Database platforms",
   "priority":"3",


### PR DESCRIPTION
This PR changes the `Yugabyte` with `YugabyteDB` as we prefer to use the YugabyteDB as the product name in place of Yugabyte which is the company name. 