### PR TITLE
Fix typo in intro/configuration/index.html

### DIFF
--- a/docs/intro/configuration/index.html
+++ b/docs/intro/configuration/index.html
@@ -175,7 +175,7 @@ datasource:
 
 <h2 id="testing">For Testing with ebean-test</h2>
 <p>
-  <code>ebean-test</code> was built to help with testing against against the target database
+  <code>ebean-test</code> was built to help with testing against the target database
   (Postgres, MySql, MariaDB, SQLServer, Oracle ...).
   Docker especially can be used to programmatically setup and initialise the database for testing
   purposes.


### PR DESCRIPTION
Fix typo in doubling "against" word