### PR TITLE
Fix dependency in `docs/db-migrations`

### DIFF
--- a/docs/db-migrations/index.html
+++ b/docs/db-migrations/index.html
@@ -41,7 +41,7 @@
 <pre content="xml">
   <dependency>
     <groupId>io.ebean</groupId>
-    <artifactId>ebean-test</artifactId>
+    <artifactId>ebean-ddl-generator</artifactId>
     <version>17.2.0</version>
     <scope>test</scope>
   </dependency>


### PR DESCRIPTION
This looked wrong to me:

> OR add ebean-ddl-generator as a test scope dependency.
> ... ` <artifactId>ebean-test</artifactId>`


Signed-off-by: Mahied Maruf <contact@mechite.com>