### PR TITLE
Docs: clarify findStream() vs findList().stream()

### DIFF
--- a/docs/query/dtoquery.html
+++ b/docs/query/dtoquery.html
@@ -164,7 +164,9 @@ database.findDto(CustomerDto.class, sql)
 <p>
   <em>findStream</em> is similar to findEach where we process the result one at a time.
   We should use a <code>try with resources</code> block to ensure the underlying resources
-  are closed.
+  are closed. As with entity queries, the connection is held open for the lifetime of the
+  stream - for small/bounded results that you collect anyway prefer <code>findList().stream()</code>
+  (see <a href="streaming#findStream-vs-findList">findStream() vs findList().stream()</a>).
 </p>
 <pre content="java">
 

--- a/docs/query/streaming.html
+++ b/docs/query/streaming.html
@@ -24,14 +24,43 @@
 <p>
   From Ebean version 12.3.5 these streaming queries use an "adaptive persistence context".
   This means that <a href="#findEach">findEach</a>, <a href="#findIterate">findIterate</a>,
-  and <a href="#findStream">findStream</a> will work equally as well against small query
-  results as <a href="findList">findList</a>. After 1000 beans are processed the queries adapt
+  and <a href="#findStream">findStream</a> work equally as well against small query
+  results as <a href="findList">findList</a> <em>in terms of persistence context and memory</em>.
+  After 1000 beans are processed the queries adapt
   the persistence context they use to ensure it does not hold all the beans (and run out of memory
   when processing very large results).
 </p>
 <p>
   Queries processing less than 1000 beans use a single normal persistence context. After 1000
   beans the persistence context adapts such that it does not hold all the beans.
+</p>
+
+<h2 id="findStream-vs-findList">findStream() vs findList().stream()</h2>
+<p>
+  These look similar but have different resource semantics - choose based on result size
+  and how you consume it.
+</p>
+<ul>
+  <li>
+    <strong><code>findList().stream()</code></strong> executes the query, materialises the rows,
+    <em>releases the connection</em>, and then streams over an in-memory list. There are no open
+    database resources to manage and no <code>try with resources</code> block is needed.
+    Prefer this for small or bounded results (for example when you apply <code>setMaxRows</code>)
+    that you intend to collect anyway - it is the simpler, safer default for list-sized results.
+  </li>
+  <li>
+    <strong><code>findStream()</code></strong> streams rows directly from the JDBC cursor. It holds
+    a connection (and an implicit transaction) open for the <em>whole lifetime of the stream
+    pipeline</em>, so it must be closed via <code>try with resources</code>. Prefer it when the
+    result may be large, when you want constant memory use, or when you want to short-circuit
+    (<code>limit</code>, <code>findFirst</code>, <code>takeWhile</code>) without loading everything.
+  </li>
+</ul>
+<p>
+  Rule of thumb: reach for <a href="#findStream">findStream</a> / <a href="#findEach">findEach</a> /
+  <a href="#findIterate">findIterate</a> for <em>large or lazily-consumed</em> results; for small,
+  fully-materialised results <code>findList().stream()</code> is clearer and does not hold database
+  resources open.
 </p>
 
 <h2 id="findEach">findEach</h2>
@@ -87,6 +116,10 @@ new QCustomer()
 <p>
   Execute the query processing the result as a stream.
   Use a <code>try with resources</code> block to ensure the resources held by the stream are closed.
+  The connection (and implicit transaction) is held open until the stream is closed, so if you
+  simply want the whole result as a list prefer <a href="findList">findList</a> /
+  <code>findList().stream()</code> (see
+  <a href="#findStream-vs-findList">findStream() vs findList().stream()</a>).
 </p>
 
 <pre content="java">


### PR DESCRIPTION
## Why

The streaming docs (`docs/query/streaming.html` and `docs/query/dtoquery.html`) describe `findStream()` only as a tool for *very large* results and never contrast it with `findList().stream()`. The "adaptive persistence context" note even implies the two are interchangeable for small results:

> findStream ... will work equally as well against small query results as findList.

That nudges readers toward always using `findStream()`, which misses the real trade-off: `findStream()` holds a **JDBC cursor + pooled connection (and an implicit transaction) open for the entire lifetime of the downstream stream pipeline** and must be closed via try-with-resources. For a small/bounded result you fully materialise anyway, `findList().stream()` fetches, **releases the connection immediately**, and needs no resource management.

## What

- **streaming.html**
  - New section "findStream() vs findList().stream()" with a clear decision rule.
  - Softened the adaptive-persistence-context wording to clarify it's about memory / persistence context, not resource lifecycle.
  - Added a closing note under the findStream heading pointing small/collected use-cases to findList().stream().
- **dtoquery.html**
  - Added the same guidance + cross-link in its findStream section.

No behavioural/code changes — documentation only.
